### PR TITLE
Add searchable config option for @ng-select/ng-select

### DIFF
--- a/projects/moment-timezone-picker/src/lib/core/defaults/_select-config.default.ts
+++ b/projects/moment-timezone-picker/src/lib/core/defaults/_select-config.default.ts
@@ -7,5 +7,5 @@ export const DEFAULT_SELECT_CONFIG: SelectConfig = {
   clearOnBackspace: true,
   closeOnSelect: true,
   appendTo: null,
-  searcchable: true,
+  searchable: true,
 };

--- a/projects/moment-timezone-picker/src/lib/core/defaults/_select-config.default.ts
+++ b/projects/moment-timezone-picker/src/lib/core/defaults/_select-config.default.ts
@@ -6,5 +6,6 @@ export const DEFAULT_SELECT_CONFIG: SelectConfig = {
   appearance: 'underline',
   clearOnBackspace: true,
   closeOnSelect: true,
-  appendTo: null
+  appendTo: null,
+  searcchable: true,
 };

--- a/projects/moment-timezone-picker/src/lib/core/types/_select-config.model.ts
+++ b/projects/moment-timezone-picker/src/lib/core/types/_select-config.model.ts
@@ -5,5 +5,5 @@ export interface SelectConfig {
   closeOnSelect: boolean;
   dropdownPosition: 'auto' | 'bottom' | 'top';
   hideSelected: boolean;
-  searcchable: boolean;
+  searchable: boolean;
 }

--- a/projects/moment-timezone-picker/src/lib/core/types/_select-config.model.ts
+++ b/projects/moment-timezone-picker/src/lib/core/types/_select-config.model.ts
@@ -5,4 +5,5 @@ export interface SelectConfig {
   closeOnSelect: boolean;
   dropdownPosition: 'auto' | 'bottom' | 'top';
   hideSelected: boolean;
+  searcchable: boolean;
 }

--- a/projects/moment-timezone-picker/src/lib/moment-timezone-picker.component.ts
+++ b/projects/moment-timezone-picker/src/lib/moment-timezone-picker.component.ts
@@ -35,7 +35,8 @@ import {DEFAULT_SELECT_CONFIG, formatZone, SelectConfig, TZone} from './core';
                  [clearOnBackspace]="config.clearOnBackspace"
                  [closeOnSelect]="config.closeOnSelect"
                  [dropdownPosition]="config.dropdownPosition"
-                 [hideSelected]="config.hideSelected">
+                 [hideSelected]="config.hideSelected"
+                 [searchable]="config.searchable">
       </ng-select>
     </div>
   `,


### PR DESCRIPTION
For some applications you don't want the user to be able to type into the dropdown, so I just added the searchable option to SelectConfig and bound it to the appropriate ng-select input... tested it out, works as expected. Please can you merge and publish an update to npm?

Related to: https://github.com/ng-select/ng-select/issues/626